### PR TITLE
Add cmn_echo_term and rewire existing echo methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+indent_style = tab
+indent_size = 2
+

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Actually, the library includes that parser for reasons of convenience.
 Last but not least, the library contains valuable knowledge and experience
 of coworkers who showed my one or two tricks.
 
+The [Penbase](https://github.com/Penbase) github organization also contributed
+to this helper script with new or enhanced functions with their own
+[fork](https://github.com/Penbase/bash-common-helpers).
+
 ## License
 
 Released under the MIT License (MIT) &ndash; see file LICENSE in this software's

--- a/bash-common-helpers.sh
+++ b/bash-common-helpers.sh
@@ -65,8 +65,7 @@ function cmn_assert_running_as_root {
 # cmn_echo_info "Task completed."
 #
 function cmn_echo_info {
-	local green=$(tput setaf 2)
-	cmn_echo_term "${green}" "$@"
+	cmn_echo_term "2" "$@"
 }
 
 # cmn_echo_important message ...
@@ -77,8 +76,7 @@ function cmn_echo_info {
 # cmn_echo_important "Please complete the following task manually."
 #
 function cmn_echo_important {
-  local yellow=$(tput setaf 3)
-	cmn_echo_term "${yellow}" "$@"
+	cmn_echo_term "3" "$@"
 }
 
 # cmn_echo_warn message ...
@@ -89,9 +87,7 @@ function cmn_echo_important {
 # cmn_echo_warn "There was a failure."
 #
 function cmn_echo_warn {
-  local red=$(tput setaf 1)
-  local reset=$(tput sgr0)
-	cmn_echo_term "${red}" "$@"
+	cmn_echo_term "1" "$@"
 }
 
 #
@@ -106,11 +102,11 @@ function cmn_echo_warn {
 # Example:
 # cmn_die "An error occurred."
 #
+CMN_DIE=0
 function cmn_die {
-  local red=$(tput setaf 1)
-  local reset=$(tput sgr0)
-  echo >&2 -e "${red}$@${reset}"
-  exit 1
+	CMN_DIE=1
+	cmn_echo_term "1" "$@"
+	exit 1
 }
 
 #
@@ -723,9 +719,9 @@ function cmn_log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') $1"
 }
 
-# cmn_echo_info color message ...
+# cmn_echo_info color_index message ...
 #
-# Writes the given messages in the specified TERM color to standard output.
+# Writes the given messages in the specified TERM color_index to standard output.
 # If the current terminal does not support colours, fallbacks to a simple echo
 #
 function cmn_echo_term() {
@@ -735,11 +731,16 @@ function cmn_echo_term() {
 	fi
 	if [ -n "${ncolors}" ] && [ "${ncolors}" -ge "8" ]; then
 		local reset=$(tput sgr0)
-		local color="${1}"
+		local color="$(tput setaf ${1})"
 		shift
-		echo -e "${color}$@${reset}"
+		output="${color}$@${reset}"
 	else
 		shift
-		echo -e "$@"
+		output="$@"
+	fi
+	if [ -n "${CMN_DIE}" ] && [ "${CMN_DIE}" -eq "1" ]; then
+		echo >&2 -e "${output}"
+	else
+		echo -e "${output}"
 	fi
 }

--- a/bash-common-helpers.sh
+++ b/bash-common-helpers.sh
@@ -65,9 +65,8 @@ function cmn_assert_running_as_root {
 # cmn_echo_info "Task completed."
 #
 function cmn_echo_info {
-  local green=$(tput setaf 2)
-  local reset=$(tput sgr0)
-  echo -e "${green}$@${reset}"
+	local green=$(tput setaf 2)
+	cmn_echo_term "${green}" "$@"
 }
 
 # cmn_echo_important message ...
@@ -79,8 +78,7 @@ function cmn_echo_info {
 #
 function cmn_echo_important {
   local yellow=$(tput setaf 3)
-  local reset=$(tput sgr0)
-  echo -e "${yellow}$@${reset}"
+	cmn_echo_term "${yellow}" "$@"
 }
 
 # cmn_echo_warn message ...
@@ -93,7 +91,7 @@ function cmn_echo_important {
 function cmn_echo_warn {
   local red=$(tput setaf 1)
   local reset=$(tput sgr0)
-  echo -e "${red}$@${reset}"
+	cmn_echo_term "${red}" "$@"
 }
 
 #
@@ -427,7 +425,7 @@ function read_ini()
 			return 1
 		fi
 	}
-	
+
 	function check_ini_file()
 	{
 		if [ ! -r "$INI_FILE" ] ;then
@@ -436,7 +434,7 @@ function read_ini()
 			return 1
 		fi
 	}
-	
+
 	# enable some optional shell behavior (shopt)
 	function pollute_bash()
 	{
@@ -448,7 +446,7 @@ function read_ini()
 		fi
 		shopt -q -s ${SWITCH_SHOPT}
 	}
-	
+
 	# unset all local functions and restore shopt settings before returning
 	# from read_ini()
 	function cleanup_bash()
@@ -456,7 +454,7 @@ function read_ini()
 		shopt -q -u ${SWITCH_SHOPT}
 		unset -f check_prefix check_ini_file pollute_bash cleanup_bash
 	}
-	
+
 	local INI_FILE=""
 	local INI_SECTION=""
 
@@ -542,7 +540,7 @@ function read_ini()
 		cleanup_bash
 		return 0
 	fi
-	
+
 	if ! check_ini_file ;then
 		cleanup_bash
 		return 1
@@ -562,16 +560,16 @@ function read_ini()
 	local LINE_NUM=0
 	local SECTIONS_NUM=0
 	local SECTION=""
-	
+
 	# IFS is used in "read" and we want to switch it within the loop
 	local IFS=$' \t\n'
 	local IFS_OLD="${IFS}"
-	
+
 	# we need some optional shell behavior (shopt) but want to restore
 	# current settings before returning
 	local SWITCH_SHOPT=""
 	pollute_bash
-	
+
 	while read -r line || [ -n "$line" ]
 	do
 #echo line = "$line"
@@ -620,7 +618,7 @@ function read_ini()
 		IFS="="
 		read -r VAR VAL <<< "${line}"
 		IFS="${IFS_OLD}"
-		
+
 		# delete spaces around the equal sign (using extglob)
 		VAR="${VAR%%+([[:space:]])}"
 		VAL="${VAL##+([[:space:]])}"
@@ -667,7 +665,7 @@ function read_ini()
 				;;
 			esac
 		fi
-		
+
 
 		# enclose the value in single quotes and escape any
 		# single quotes and backslashes that may be in the value
@@ -676,7 +674,7 @@ function read_ini()
 
 		eval "$VARNAME=$VAL"
 	done  <"${INI_FILE}"
-	
+
 	# return also the number of parsed sections
 	eval "$INI_NUMSECTIONS_VARNAME=$SECTIONS_NUM"
 
@@ -684,7 +682,10 @@ function read_ini()
 }
 
 ###############################################################################
+# Copyright (c) 2019 Penbase
 # PENBASE common functions contribution
+# Released under the MIT License (MIT)
+# https://github.com/Penbase/bash-common-helpers/blob/master/LICENSE
 ###############################################################################
 
 # cmn_slugify some_text
@@ -720,4 +721,25 @@ function cmn_assert_env_not_empty() {
 #
 function cmn_log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') $1"
+}
+
+# cmn_echo_info color message ...
+#
+# Writes the given messages in the specified TERM color to standard output.
+# If the current terminal does not support colours, fallbacks to a simple echo
+#
+function cmn_echo_term() {
+	ncolors=0
+	if [ "${TERM}" != "unknown" ]; then
+		ncolors="$(tput colors)"
+	fi
+	if [ -n "${ncolors}" ] && [ "${ncolors}" -ge "8" ]; then
+		local reset=$(tput sgr0)
+		local color="${1}"
+		shift
+		echo -e "${color}$@${reset}"
+	else
+		shift
+		echo -e "$@"
+	fi
 }


### PR DESCRIPTION
Should improve compatibility for some scripts running without an actual terminal
