### PR TITLE
Fix unbound TERM variable in some environments

### DIFF
--- a/bash-common-helpers.sh
+++ b/bash-common-helpers.sh
@@ -726,6 +726,7 @@ function cmn_log() {
 #
 function cmn_echo_term() {
 	ncolors=0
+	TERM="${TERM:-unknown}"
 	if [ "${TERM}" != "unknown" ]; then
 		ncolors="$(tput colors)"
 	fi


### PR DESCRIPTION
Following #3, there is an issue in some environments where the `TERM` environment variable is not bound at all.